### PR TITLE
Add GH Actions workflow for golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,19 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+  pull_request:
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.35


### PR DESCRIPTION
For now, we always run the workflow, regardless of branch and reviews. This
means that PRs could change the workflow code and have access to Github secrets
or infrastructure (clusters, etc). But we don't have any of those yet, nor we
will have for a bit.

For an example of a correct run that fails tests, see https://github.com/viccuad/hypper/pull/1
(where golangci-lint is run on an existing branch, instead of the empty main branch).

Closes #6.