### PR TITLE
Add GH Actions CI for building and testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+  pull_request:
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.15.x]
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Cache Go modules
+        # not supported on windows with gh actions at the moment
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Setup Go for Building
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.13.7'
+      - name: Build Hypper
+        run: make build
+      - name: Test Hypper
+        run: make test
+      - name: Show Coverage of Hypper
+        run: make coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Go for Building
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.13.7'
+          go-version: '^1.15.7'
       - name: Build Hypper
         run: make build
       - name: Test Hypper

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+bin/

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 # vendor/
 
 bin/
+
+# Local dev files
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,51 @@
+BINDIR	:= $(CURDIR)/bin
+BINNAME	?= hypper
+INSTALL_PATH ?= /usr/local/bin
+
+SHELL      = /usr/bin/env bash
+
+GIT_COMMIT = $(shell git rev-parse HEAD)
+GIT_SHA    = $(shell git rev-parse --short HEAD)
+GIT_TAG    = $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null)
+GIT_DIRTY  = $(shell test -n "`git status --porcelain`" && echo "dirty" || echo "clean")
+
+ifdef VERSION
+	BINARY_VERSION = $(VERSION)
+endif
+BINARY_VERSION ?= ${GIT_TAG}
+
+ifneq ($(BINARY_VERSION),)
+	LDFLAGS += -X helm.sh/helm/v3/internal/version.version=${BINARY_VERSION}
+endif
+
+.PHONY: all
+all: build
+
+.PHONY: build
+build: lint $(BINDIR)/$(BINNAME)
+
+$(BINDIR)/$(BINNAME): $(SRC)
+	GO111MODULE=on go build $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o '$(BINDIR)'/$(BINNAME) ./cmd/hypper
+
+.PHONY: install
+install: build
+	@install "$(BINDIR)/$(BINNAME)" "$(INSTALL_PATH)/$(BINNAME)"
+
+.PHONY: test
+test: lint
+	ginkgo ./...
+
+.PHONY: lint
+lint: fmt vet
+
+.PHONY: vet
+vet:
+	go vet ./...
+
+.PHONY: fmt
+fmt:
+	go fmt ./...
+
+.PHONY: clean
+clean:
+	rm -Rfv $(CURDIR)/bin

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ all: build
 .PHONY: build
 build: lint $(BINDIR)/$(BINNAME)
 
-# Rebuild the buinary if any of these files change
+# Rebuild the binary if any of these files change
 SRC := $(shell find . -type f -name '*.go' -print) go.mod go.sum
 
 $(BINDIR)/$(BINNAME): $(SRC)

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,14 @@ GIT_SHA    = $(shell git rev-parse --short HEAD)
 GIT_TAG    = $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null)
 GIT_DIRTY  = $(shell test -n "`git status --porcelain`" && echo "dirty" || echo "clean")
 
+# go option
+PKG        := ./...
+TAGS       :=
+TESTS      := .
+TESTFLAGS  :=
+LDFLAGS    := -w -s
+GOFLAGS    :=
+
 ifdef VERSION
 	BINARY_VERSION = $(VERSION)
 endif
@@ -24,6 +32,9 @@ all: build
 .PHONY: build
 build: lint $(BINDIR)/$(BINNAME)
 
+# Rebuild the buinary if any of these files change
+SRC := $(shell find . -type f -name '*.go' -print) go.mod go.sum
+
 $(BINDIR)/$(BINNAME): $(SRC)
 	GO111MODULE=on go build $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o '$(BINDIR)'/$(BINNAME) ./cmd/hypper
 
@@ -32,8 +43,21 @@ install: build
 	@install "$(BINDIR)/$(BINNAME)" "$(INSTALL_PATH)/$(BINNAME)"
 
 .PHONY: test
-test: lint
-	ginkgo ./...
+test: lint build
+test: TESTFLAGS += -race -v
+test: test-unit
+
+.PHONY: test-unit
+test-unit:
+	@echo
+	@echo "==> Running unit tests <=="
+	GO111MODULE=on go test $(GOFLAGS) -run $(TESTS) $(PKG) $(TESTFLAGS)
+
+.PHONY: coverage
+coverage:
+	@echo
+	@echo "==> Running coverage tests <=="
+	@ ./scripts/coverage.sh
 
 .PHONY: lint
 lint: fmt vet
@@ -48,4 +72,5 @@ fmt:
 
 .PHONY: clean
 clean:
-	rm -Rfv $(CURDIR)/bin
+	rm $(BINDIR)/$(BINNAME)
+	rmdir $(BINDIR)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/mattfarina/hypper
+
+go 1.15

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright The Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+covermode=${COVERMODE:-atomic}
+coverdir=$(mktemp -d /tmp/coverage.XXXXXXXXXX)
+profile="${coverdir}/cover.out"
+
+pushd /
+hash goveralls 2>/dev/null || go get github.com/mattn/goveralls
+popd
+
+generate_cover_data() {
+  for d in $(go list ./...) ; do
+    (
+      local output="${coverdir}/${d//\//-}.cover"
+      go test -coverprofile="${output}" -covermode="$covermode" "$d"
+    )
+  done
+
+  echo "mode: $covermode" >"$profile"
+  grep -h -v "^mode:" "$coverdir"/*.cover >>"$profile"
+}
+
+push_to_coveralls() {
+  goveralls -coverprofile="${profile}" -service=circle-ci
+}
+
+generate_cover_data
+go tool cover -func "${profile}"
+
+case "${1-}" in
+  --html)
+    go tool cover -html "${profile}"
+    ;;
+  --coveralls)
+    push_to_coveralls
+    ;;
+esac
+


### PR DESCRIPTION
This adds a Makefile for the project, and a GH Actions workflow with steps for building, testing and showing coverage (for MacOS, Windows and Ubuntu).

Closes #5.