### PR TITLE
Emojis :pizza:

### DIFF
--- a/cmd/hypper/hypper.go
+++ b/cmd/hypper/hypper.go
@@ -27,7 +27,7 @@ func main() {
 	}
 
 	if err != nil {
-		logger.Debug(eycandy.Magenta("%v"), err)
+		logger.Debug(eyecandy.Magenta("%v"), err)
 		os.Exit(1)
 	}
 
@@ -42,7 +42,7 @@ func main() {
 	})
 
 	if err := cmd.Execute(); err != nil {
-		logger.Debug(eycandy.Magenta("%v"), err)
+		logger.Debug(eyecandy.Magenta("%v"), err)
 		os.Exit(1)
 	}
 }

--- a/cmd/hypper/install.go
+++ b/cmd/hypper/install.go
@@ -36,7 +36,6 @@ func newInstallCmd(actionConfig *helmAction.Configuration, logger log.Logger) *c
 			if err != nil {
 				return err
 			}
-			// TODO use output package for formatting:
 			logger.Info(eyecandy.ESPrint(settings.NoEmojis, "Done! :clapping_hands:"))
 			return nil
 		},

--- a/cmd/hypper/install.go
+++ b/cmd/hypper/install.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/mattfarina/hypper/pkg/eyecandy"
 	"github.com/mattfarina/log"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -29,15 +30,14 @@ func newInstallCmd(actionConfig *helmAction.Configuration, logger log.Logger) *c
 		Long:  installDesc,
 		Args:  require.MinimumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			// TODO use output package for formatting:
-			logger.Infof("Installing %s…", args[0])
+			logger.Info(eyecandy.ESPrintf(settings.NoEmojis, ":cruise_ship: Installing %s…", args[0]))
 			// TODO decide how to use returned rel:
 			_, err := runInstall(args, client, valuesOpts, logger)
 			if err != nil {
 				return err
 			}
 			// TODO use output package for formatting:
-			logger.Info("Done!")
+			logger.Info(eyecandy.ESPrint(settings.NoEmojis, "Done! :clapping_hands:"))
 			return nil
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/fatih/color v1.7.0
+	github.com/kyokomi/emoji/v2 v2.2.8
 	github.com/mattfarina/log v0.1.0
 	github.com/mattn/go-shellwords v1.0.10
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -412,6 +412,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kyokomi/emoji/v2 v2.2.8 h1:jcofPxjHWEkJtkIbcLHvZhxKgCPl6C7MyjTrD4KDqUE=
+github.com/kyokomi/emoji/v2 v2.2.8/go.mod h1:JUcn42DTdsXJo1SWanHh4HKDEyPaR5CqkmoirZZP9qE=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq6+3iTQz8KNCLtVX6idSoTLdUw=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=
@@ -436,6 +438,7 @@ github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
 github.com/mattfarina/log v0.1.0 h1:4hRXohIiGsw/x/+fJ4rwCbb77OjSTHd8Ll311xjoH/I=
 github.com/mattfarina/log v0.1.0/go.mod h1:x7MYYu+oSRHzamt1LAABoiNEjb/j0wq4tVHvVSr0Pzw=
+github.com/mattfarina/pkg v0.0.0-20151113151254-a5dff5fc5aff h1:XcTh+bFRGmHQQ191scQBVjzByFQkLjsZ6+7RqHoX3Hw=
 github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRUIY4=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 	"os"
-	"regexp"
 	"strconv"
 
 	"github.com/mattfarina/log"
@@ -43,9 +42,4 @@ func (s *EnvSettings) EnvVars() map[string]string {
 		"HYPPER_NOCOLORS": fmt.Sprint(s.NoColors),
 		"HYPPER_NOEMOJIS": fmt.Sprint(s.NoEmojis),
 	}
-}
-
-func RemoveEmojiFromString(s string) string {
-	re := regexp.MustCompile(`:[a-zA-Z0-9-_+]+?:`)
-	return re.ReplaceAllString(s, "")
 }

--- a/pkg/cli/environment_test.go
+++ b/pkg/cli/environment_test.go
@@ -9,63 +9,6 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func TestEmojis(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "plain string",
-			input:    "this is a plain string",
-			expected: "this is a plain string",
-		},
-		{
-			name:     "plain utf-8 string",
-			input:    "\u2000-\u3300",
-			expected: "\u2000-\u3300",
-		},
-		{
-			name:     "pure emoji string",
-			input:    ":pizza::beer:",
-			expected: "",
-		},
-		{
-			name:     "mixed string",
-			input:    ":pizza: beer",
-			expected: " beer",
-		},
-		{
-			name:     "weird edge cases",
-			input:    ":pizza: :beer: :pizza beer:",
-			expected: "  :pizza beer:",
-		},
-		{
-			name:     "double colon",
-			input:    ":: test",
-			expected: ":: test",
-		},
-		{
-			name:     "double colon emoji mixup",
-			input:    "::pizza::",
-			expected: "::",
-		},
-		{
-			name:     "do not touch native utf-8 inside colons",
-			input:    ":\u2000-\u3300:",
-			expected: ":\u2000-\u3300:",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s := RemoveEmojiFromString(tt.input)
-			if tt.expected != s {
-				t.Errorf("expected %s got %s", tt.expected, s)
-			}
-		})
-	}
-}
-
 func TestEnvSettings(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/eyecandy/colors.go
+++ b/pkg/eyecandy/colors.go
@@ -1,4 +1,4 @@
-package eycandy
+package eyecandy
 
 import (
 	"github.com/fatih/color"

--- a/pkg/eyecandy/emoji.go
+++ b/pkg/eyecandy/emoji.go
@@ -1,0 +1,26 @@
+package eyecandy
+
+import (
+	"fmt"
+	"github.com/kyokomi/emoji/v2"
+	"regexp"
+)
+
+func ESPrintf(emojisDisabled bool, format string, v ...interface{}) string {
+	if emojisDisabled {
+		return fmt.Sprintf(removeEmojiFromString(format), v...)
+	}
+	return emoji.Sprintf(format, v...)
+}
+
+func ESPrint(emojisDisabled bool, s string) string {
+	if emojisDisabled {
+		return fmt.Sprint(removeEmojiFromString(s))
+	}
+	return emoji.Sprint(s)
+}
+
+func removeEmojiFromString(s string) string {
+	re := regexp.MustCompile(`:[a-zA-Z0-9-_+]+?:`)
+	return re.ReplaceAllString(s, "")
+}

--- a/pkg/eyecandy/emoji_test.go
+++ b/pkg/eyecandy/emoji_test.go
@@ -1,0 +1,62 @@
+package eyecandy
+
+import (
+	"testing"
+)
+
+func TestEmojis(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "plain string",
+			input:    "this is a plain string",
+			expected: "this is a plain string",
+		},
+		{
+			name:     "plain utf-8 string",
+			input:    "\u2000-\u3300",
+			expected: "\u2000-\u3300",
+		},
+		{
+			name:     "pure emoji string",
+			input:    ":pizza::beer:",
+			expected: "",
+		},
+		{
+			name:     "mixed string",
+			input:    ":pizza: beer",
+			expected: " beer",
+		},
+		{
+			name:     "weird edge cases",
+			input:    ":pizza: :beer: :pizza beer:",
+			expected: "  :pizza beer:",
+		},
+		{
+			name:     "double colon",
+			input:    ":: test",
+			expected: ":: test",
+		},
+		{
+			name:     "double colon emoji mixup",
+			input:    "::pizza::",
+			expected: "::",
+		},
+		{
+			name:     "do not touch native utf-8 inside colons",
+			input:    ":\u2000-\u3300:",
+			expected: ":\u2000-\u3300:",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := removeEmojiFromString(tt.input)
+			if tt.expected != s {
+				t.Errorf("expected %s got %s", tt.expected, s)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support for outputting emojis to the cli.
It uses the common `:emoji:` notation known from popular messaging clients like element.

examples:
`:+1: `-> :+1: 
`:pizza:` -> :pizza: 
`:100:` -> :100: ....

Closes #2 