### PR TITLE
Enable matrix for go version testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: ["1.16.0-beta1", "1.15.7", "1.14.14"]
         os: [macos-latest, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -27,7 +27,8 @@ jobs:
       - name: Setup Go for Building
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.15.7'
+          go-version: ${{ matrix.go-version }}
+          stable: '!contains(${{ matrix.go }}, "beta") && !contains(${{ matrix.go }}, "rc")'
       - name: Build Hypper
         run: make build
       - name: Test Hypper


### PR DESCRIPTION
We should test at least the maintained go versions so we can check
if something fails on any of those versions