### PR TITLE
Drop restore key from CI cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - name: Setup Go for Building
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
There is no need to look further than the specific cache for
the combination of os+go.sum. Either we have a hit and use the
full cache or the hash of go.sum has changed and we need a new
cache for the build. Reusing a generic cache is not useful and
can cause problems