### PR TITLE
Add missing test for unknown subcommand

### DIFF
--- a/cmd/hypper/root_test.go
+++ b/cmd/hypper/root_test.go
@@ -27,3 +27,11 @@ func TestRootCmd(t *testing.T) {
 		})
 	}
 }
+
+func TestUnknownSubCmd(t *testing.T) {
+	_, _, err := executeCommandStdinC("foobar")
+
+	if err == nil || err.Error() != `unknown command "foobar" for "hypper"` {
+		t.Errorf("Expect unknown command error, got %q", err)
+	}
+}


### PR DESCRIPTION
This PR adds a test for running the command with an unknown subcommand.

Closes #7 