### PR TITLE
Updating golangci-lint to 1.36

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,5 +19,5 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.35
+          version: v1.36
           args: -v

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,4 +20,8 @@ jobs:
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.36
-          args: -v
+
+          # Setting the timeout to the default. In the GH Action it is running
+          # for just 30s and timing out. Helm itself takes 45s to run in CircleCI
+          # This restores the default timeout.
+          args: -v --timeout 1m0s


### PR DESCRIPTION
Note, I noticed the lint process was taking more than 29s and timing out. golangci-lint defaults to a 1m0s timeout but that was not happening. Helm takes about 45s to lint in CircleCI. So, I increased the lint timeout period.