### PR TITLE
moving to new log-go home

### DIFF
--- a/cmd/hypper/hypper.go
+++ b/cmd/hypper/hypper.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"strings"
 
+	"github.com/Masterminds/log-go"
+	logcli "github.com/Masterminds/log-go/impl/cli"
 	"github.com/mattfarina/hypper/pkg/cli"
 	"github.com/mattfarina/hypper/pkg/eyecandy"
-	"github.com/mattfarina/log-go"
-	logcli "github.com/mattfarina/log-go/impl/cli"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 	helmAction "helm.sh/helm/v3/pkg/action"

--- a/cmd/hypper/hypper_test.go
+++ b/cmd/hypper/hypper_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Masterminds/log-go"
 	"github.com/mattfarina/hypper/internal/test"
-	"github.com/mattfarina/log-go"
 	"helm.sh/helm/v3/pkg/chartutil"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
 	"helm.sh/helm/v3/pkg/release"
@@ -18,8 +18,8 @@ import (
 
 	stdlog "log"
 
+	logStd "github.com/Masterminds/log-go/impl/std"
 	"github.com/mattfarina/hypper/pkg/cli"
-	logStd "github.com/mattfarina/log-go/impl/std"
 	"github.com/mattn/go-shellwords"
 	"github.com/spf13/cobra"
 	helmAction "helm.sh/helm/v3/pkg/action"

--- a/cmd/hypper/install.go
+++ b/cmd/hypper/install.go
@@ -3,8 +3,8 @@ package main
 import (
 	"os"
 
+	"github.com/Masterminds/log-go"
 	"github.com/mattfarina/hypper/pkg/eyecandy"
-	"github.com/mattfarina/log-go"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"helm.sh/helm/v3/cmd/helm/require"

--- a/cmd/hypper/root.go
+++ b/cmd/hypper/root.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"os"
 
+	"github.com/Masterminds/log-go"
 	"github.com/fatih/color"
-	"github.com/mattfarina/log-go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	helmAction "helm.sh/helm/v3/pkg/action"

--- a/cmd/hypper/uninstall.go
+++ b/cmd/hypper/uninstall.go
@@ -3,8 +3,8 @@ package main
 import (
 	"time"
 
+	"github.com/Masterminds/log-go"
 	"github.com/mattfarina/hypper/pkg/eyecandy"
-	"github.com/mattfarina/log-go"
 	"github.com/spf13/cobra"
 	"helm.sh/helm/v3/cmd/helm/require"
 	helmAction "helm.sh/helm/v3/pkg/action"

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/fatih/color v1.10.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/kyokomi/emoji/v2 v2.2.8
-	github.com/mattfarina/log-go v0.3.0
+	github.com/Masterminds/log-go v0.4.0
 	github.com/mattn/go-shellwords v1.0.10
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd h1:sjQovDkwrZp
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/log-go v0.4.0 h1:RkiJ3U65qjGtHRfV2T74DurURYDDz0sBs7U383hC3Qs=
+github.com/Masterminds/log-go v0.4.0/go.mod h1:xPgU2yZAUbQCkvzB2I8OaqV5OFqOmq907g++YvJDL5Y=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig/v3 v3.2.0 h1:P1ekkbuU73Ui/wS0nK1HOM37hh4xdfZo485UPf8rc+Y=


### PR DESCRIPTION
The github.com/mattfarina/log-go package moved to its new home
in an organization. This change uses it in its new home.